### PR TITLE
Add API-key-free fallback panoramas

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ## 機能
 
+- Google API キーなしでも遊べるオープンデータの 360° 画像セットを内蔵
 - 20 件の候補リストを作成し、その中から 3 ラウンド分をランダムに出題
 - Google Maps JavaScript API の Street View ビューア（ドラッグで視点移動、ホイール/ピンチでズーム）
 - Leaflet ベースの推測用マップでタップ/クリックして位置を指定
@@ -22,7 +23,7 @@
    python -m http.server 8000
    ```
    その後 `http://localhost:8000/` にアクセスします。
-3. 画面右上の「APIキー」欄に Google Maps Platform の API キーを入力して「保存」します（ブラウザのローカルストレージに保存されます）。
+3. Google Street View を利用したい場合は、画面右上の「Google APIキー (任意)」欄に Google Maps Platform の API キーを入力して「保存」します（ブラウザのローカルストレージに保存されます）。未入力でも内蔵のオープンデータ画像でプレイできます。
 4. 「ゲーム開始」を押すと候補の取得が始まり、ラウンド 1 がスタートします。
 5. ストリートビューを見ながら地図をクリック/タップして推測した位置をマークし、「この場所にする！」で回答します。
 6. 結果パネルで距離と得点を確認し、「次のラウンド ▶」で進行します。3 ラウンド終えると合計スコアが表示されます。
@@ -35,7 +36,8 @@
   - `docs/style.css`: レイアウトやテーマカラーを定義したスタイルシート
   - `docs/app.js`: ゲームロジックと Street View メタデータ取得処理
 - Leaflet は CDN から読み込んでいます。オフライン対応が必要な場合はローカルにホストするか、バンドルしてください。
-- Google Maps JavaScript API は動的に読み込みます。API キーは `localStorage` に保存され、`window.GOOGLE_MAPS_API_KEY` にも反映されます。
+- Google Maps JavaScript API は動的に読み込みます。API キーは `localStorage` に保存され、`window.GOOGLE_MAPS_API_KEY` にも反映されます。API キーが未設定の場合は Photo Sphere Viewer を使ってオープンデータの 360° 画像を表示します。
+- API キー未設定時に表示する 360° 画像は、Pannellum のサンプルや Google Developers の VR データセットなど CC ライセンス/公開素材を参照しています。
 - Street View の候補は世界各地の都市圏をランダムにサンプリングし、メタデータ API から取得しています。クォータ制限に注意してください。
 
 ## ライセンス

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,12 @@
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
           integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 
+  <!-- Photo Sphere Viewer (APIキー不要の 360° ビューア) -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.2.0/dist/photo-sphere-viewer.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/uevent@2.0.0/browser.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.137.5/build/three.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/photo-sphere-viewer@4.2.0/dist/photo-sphere-viewer.min.js"></script>
+
   <script>
     try {
       window.GOOGLE_MAPS_API_KEY = localStorage.getItem('gsv_api_key') || '';
@@ -35,7 +41,7 @@
         <button id="startBtn" class="btn">ゲーム開始</button>
       </div>
       <div class="pref-group api-key-group">
-        APIキー:
+        Google APIキー (任意):
         <input id="apiKeyInput" type="password" placeholder="Google Maps API Key" autocomplete="off" />
         <button id="apiKeySave" class="btn secondary small">保存</button>
         <button id="apiKeyClear" class="btn warn small">クリア</button>
@@ -46,7 +52,7 @@
   <div class="layout">
     <div style="position: relative;">
       <div id="pano"></div>
-      <div class="panel">ストリートビュー：ドラッグで見回す／スクロールでズーム</div>
+      <div class="panel">360°ビュー：ドラッグで見回す／スクロールでズーム</div>
       <div class="controls">
         <button id="guessBtn" class="btn success" disabled>この場所にする！</button>
         <button id="nextBtn"  class="btn secondary" disabled>次のラウンド ▶</button>
@@ -73,11 +79,11 @@
       <!-- ローディング -->
       <div class="overlay" id="loadingOverlay" aria-hidden="true">
         <div class="card">
-          <h3>Google Street View から候補を収集中…</h3>
+          <h3 id="loadingTitle">候補を準備中…</h3>
           <div class="loadingbar" style="margin: 8px 0 10px;"><div id="loadingBar"></div></div>
           <div id="loadingText" style="color: var(--sub);">準備中</div>
-          <div style="margin-top:10px; color: var(--sub); font-size: 12px;">
-            ※ 利用には Google Maps Platform の API キーが必要です
+          <div id="loadingNote" style="margin-top:10px; color: var(--sub); font-size: 12px;">
+            ※ APIキーなしで遊べるサンプル画像セットを使用します
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add an open 360° panorama catalogue and Photo Sphere Viewer fallback when no Google API key is set
- update the candidate loading flow, UI text, and credits handling to support both Google Street View and the new image set
- document the optional API key workflow and data sources in the README

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dd418723c88320adbb9b2870a5b5ea