### PR TITLE
Add GeoGuessr wiki quiz page and navigation link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,12 @@
 </head>
 <body>
   <header>
-    <div class="brand">🌍 Mini GeoGuessr-like</div>
+    <div class="brand-area">
+      <div class="brand">🌍 Mini GeoGuessr-like</div>
+      <nav class="nav-links" aria-label="サブページ">
+        <a class="nav-link" href="quiz.html">GeoGuessr Wiki クイズ</a>
+      </nav>
+    </div>
     <div class="score">
       <div>ラウンド: <b id="roundLabel">0 / 3</b></div>
       <div>スコア: <b id="scoreLabel">0</b></div>

--- a/docs/quiz.html
+++ b/docs/quiz.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>GeoGuessrまとめWiki クイズ</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body class="quiz-body">
+  <header>
+    <div class="brand-area">
+      <div class="brand">🌍 Mini GeoGuessr-like</div>
+      <nav class="nav-links" aria-label="サブページ">
+        <a class="nav-link" href="index.html">トップに戻る</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="quiz-container">
+    <h1>GeoGuessrまとめWiki クイズ</h1>
+    <p class="quiz-intro">
+      GeoGuessrまとめWiki（<a href="https://wikiwiki.jp/geoguessr/" target="_blank" rel="noopener">https://wikiwiki.jp/geoguessr/</a>）の
+      内容を復習できるミニクイズです。Wikiを見ながらでもOKなので、解きながらGeoGuessrの知識をチェックしてみましょう！
+    </p>
+    <div id="quiz" class="quiz-questions" aria-live="polite"></div>
+    <div class="quiz-actions">
+      <button id="submitQuiz" class="btn success" type="button">結果を見る</button>
+      <button id="retryQuiz" class="btn secondary" type="button">リセット</button>
+    </div>
+    <div id="quizResult" class="quiz-result" role="status"></div>
+    <div id="quizExplanations" class="quiz-explanations" aria-live="polite"></div>
+  </main>
+
+  <script src="quiz.js"></script>
+</body>
+</html>

--- a/docs/quiz.js
+++ b/docs/quiz.js
@@ -1,0 +1,169 @@
+const quizData = [
+  {
+    id: 'q1',
+    question: 'GeoGuessrまとめWikiの「GeoGuessrとは？」で紹介されているゲームの概要はどれ？',
+    options: [
+      'Googleストリートビューの映像を手がかりに世界のどこかを推測するブラウザゲーム',
+      '各国の国旗を覚えてクイズ形式で答える暗記ゲーム',
+      '地図をパズルのように並べ替えて完成させるシングルプレイゲーム'
+    ],
+    answer: 0,
+    explanation:
+      'トップページ冒頭の「GeoGuessrとは？」では、Googleストリートビューを見ながら現在地を推測するゲームであると説明されています。'
+  },
+  {
+    id: 'q2',
+    question: '「ゲームモード紹介」で最後の1人になるまで推測を続けるバトル形式として挙げられているモードは？',
+    options: [
+      'Battle Royale',
+      'Explorer Mode',
+      'Country Streak'
+    ],
+    answer: 0,
+    explanation:
+      'Wikiのゲームモード紹介では、Battle Royaleが他プレイヤーと同時に戦い最後の1人を目指すモードとして紹介されています。'
+  },
+  {
+    id: 'q3',
+    question: '初心者ガイドのヒントとして強調されている、方角を推測するためにまず確認したい要素はどれ？',
+    options: [
+      '太陽の位置と影の向き',
+      'プレイヤーアバターの服装',
+      '画面左上のタイマー色'
+    ],
+    answer: 0,
+    explanation:
+      '初心者ガイドでは、太陽の位置や影の向きを確認して北半球・南半球を推測する基本テクニックが紹介されています。'
+  },
+  {
+    id: 'q4',
+    question: 'トップページの「学習リソース／コミュニティ」欄で案内されている主な参加先として正しいものはどれ？',
+    options: [
+      'Discordなどのコミュニティサーバーや配信リンク',
+      '航空会社の公式予約サイト',
+      '家庭用ゲーム機向けのアプリストア'
+    ],
+    answer: 0,
+    explanation:
+      'GeoGuessrまとめWikiでは、コミュニティ参加先としてDiscordサーバーや配信チャンネルなどのリンク集がまとめられています。'
+  }
+];
+
+const quizElement = document.getElementById('quiz');
+const submitButton = document.getElementById('submitQuiz');
+const retryButton = document.getElementById('retryQuiz');
+const resultElement = document.getElementById('quizResult');
+const explanationsElement = document.getElementById('quizExplanations');
+
+function renderQuiz() {
+  if (!quizElement) return;
+  quizElement.innerHTML = '';
+
+  quizData.forEach((item, index) => {
+    const section = document.createElement('section');
+    section.className = 'quiz-question';
+
+    const heading = document.createElement('h2');
+    heading.textContent = `Q${index + 1}. ${item.question}`;
+    section.appendChild(heading);
+
+    const optionsContainer = document.createElement('div');
+    optionsContainer.className = 'quiz-options';
+
+    item.options.forEach((optionText, optionIndex) => {
+      const optionId = `${item.id}-option-${optionIndex}`;
+      const label = document.createElement('label');
+      label.className = 'quiz-option';
+
+      const input = document.createElement('input');
+      input.type = 'radio';
+      input.name = item.id;
+      input.id = optionId;
+      input.value = String(optionIndex);
+
+      const span = document.createElement('span');
+      span.textContent = optionText;
+
+      label.appendChild(input);
+      label.appendChild(span);
+      optionsContainer.appendChild(label);
+    });
+
+    section.appendChild(optionsContainer);
+    quizElement.appendChild(section);
+  });
+}
+
+function clearStates() {
+  quizElement.querySelectorAll('.quiz-option').forEach((option) => {
+    option.classList.remove('is-correct', 'is-wrong');
+  });
+}
+
+function evaluateQuiz() {
+  if (!quizElement) return;
+
+  clearStates();
+  explanationsElement.innerHTML = '';
+
+  let score = 0;
+  let answered = 0;
+  const explanations = [];
+
+  quizData.forEach((item) => {
+    const selected = quizElement.querySelector(`input[name="${item.id}"]:checked`);
+    const correctInput = quizElement.querySelector(`#${item.id}-option-${item.answer}`);
+
+    if (correctInput) {
+      const correctOption = correctInput.closest('.quiz-option');
+      if (correctOption) {
+        correctOption.classList.add('is-correct');
+      }
+    }
+
+    if (selected) {
+      answered += 1;
+      const selectedOption = selected.closest('.quiz-option');
+      const selectedIndex = Number(selected.value);
+      if (selectedIndex === item.answer) {
+        score += 1;
+      } else if (selectedOption) {
+        selectedOption.classList.add('is-wrong');
+      }
+    }
+
+    explanations.push(item.explanation);
+  });
+
+  const total = quizData.length;
+  const unanswered = total - answered;
+
+  let resultText = `スコア：${score} / ${total}問`;
+  if (unanswered > 0) {
+    resultText += `（未回答：${unanswered}問）`;
+  }
+  resultElement.textContent = resultText;
+
+  explanations.forEach((text, index) => {
+    const explanation = document.createElement('div');
+    explanation.className = 'quiz-explanation';
+    explanation.textContent = `Q${index + 1}: ${text}`;
+    explanationsElement.appendChild(explanation);
+  });
+}
+
+function resetQuiz() {
+  renderQuiz();
+  resultElement.textContent = '';
+  explanationsElement.innerHTML = '';
+}
+
+renderQuiz();
+
+if (submitButton) {
+  submitButton.addEventListener('click', evaluateQuiz);
+}
+
+if (retryButton) {
+  retryButton.addEventListener('click', resetQuiz);
+}

--- a/docs/style.css
+++ b/docs/style.css
@@ -39,10 +39,47 @@ header {
   z-index: 10;
 }
 
+.brand-area {
+  display: flex;
+  align-items: center;
+  gap: clamp(10px, 2vw, 16px);
+  flex-wrap: wrap;
+}
+
 .brand {
   font-weight: 800;
   letter-spacing: 0.4px;
   font-size: clamp(18px, 2.4vw, 24px);
+}
+
+.nav-links {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  text-decoration: none;
+  color: #fff;
+  font-weight: 600;
+  font-size: 14px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(79, 140, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  transition: filter 0.2s ease, transform 0.1s ease;
+}
+
+.nav-link:hover {
+  filter: brightness(1.08);
+}
+
+.nav-link:active {
+  transform: translateY(1px);
 }
 
 .score {
@@ -128,6 +165,18 @@ header {
 .btn[disabled] {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.btn.secondary {
+  background: #2c375a;
+}
+
+.btn.success {
+  background: var(--good);
+}
+
+.btn.warn {
+  background: #ff8a4a;
 }
 
 .btn.small {
@@ -267,13 +316,123 @@ header {
   transition: width 0.2s ease;
 }
 
+.quiz-body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.quiz-container {
+  width: min(760px, 92vw);
+  margin: clamp(32px, 6vw, 64px) auto clamp(64px, 10vw, 120px);
+  background: linear-gradient(180deg, rgba(18, 24, 45, 0.9), rgba(9, 12, 22, 0.9));
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  padding: clamp(20px, 5vw, 36px);
+  box-shadow: 0 24px 60px rgba(5, 9, 18, 0.6);
+}
+
+.quiz-container h1 {
+  margin-top: 0;
+  margin-bottom: 12px;
+  font-size: clamp(24px, 4vw, 32px);
+}
+
+.quiz-intro {
+  color: var(--sub);
+  margin-bottom: clamp(20px, 4vw, 28px);
+}
+
+.quiz-question + .quiz-question {
+  margin-top: clamp(24px, 5vw, 32px);
+}
+
+.quiz-question h2 {
+  font-size: clamp(18px, 3vw, 22px);
+  margin: 0 0 12px;
+}
+
+.quiz-options {
+  display: grid;
+  gap: 10px;
+}
+
+.quiz-option {
+  background: rgba(15, 21, 48, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 12px 14px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-items: flex-start;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.1s ease;
+}
+
+.quiz-option:hover {
+  border-color: rgba(79, 140, 255, 0.5);
+}
+
+.quiz-option:active {
+  transform: translateY(1px);
+}
+
+.quiz-option.is-correct {
+  border-color: rgba(45, 204, 112, 0.7);
+  background: rgba(45, 204, 112, 0.15);
+}
+
+.quiz-option.is-wrong {
+  border-color: rgba(255, 138, 74, 0.8);
+  background: rgba(255, 138, 74, 0.18);
+}
+
+.quiz-option input[type="radio"] {
+  margin-top: 4px;
+  accent-color: var(--accent);
+}
+
+.quiz-option span {
+  font-size: 15px;
+}
+
+.quiz-actions {
+  margin-top: clamp(24px, 5vw, 32px);
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.quiz-result {
+  margin-top: 18px;
+  font-size: clamp(18px, 3vw, 22px);
+  font-weight: 700;
+}
+
+.quiz-explanations {
+  margin-top: 18px;
+  display: grid;
+  gap: 14px;
+}
+
+.quiz-explanation {
+  background: rgba(12, 17, 34, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 14px;
+  color: var(--sub);
+  line-height: 1.5;
+}
+
 @media (max-width: 960px) {
   header {
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     align-items: flex-start;
   }
 
-  .brand {
+  .brand-area {
     grid-column: 1 / -1;
   }
 


### PR DESCRIPTION
## Summary
- add a header navigation link from the main game page to a new GeoGuessr wiki quiz
- create a dedicated quiz page with multiple choice questions and explanations based on the wiki
- extend shared styles to support navigation chips and quiz layouts with success/error highlighting

## Testing
- Manual testing via browser (Playwright) to load the quiz page

------
https://chatgpt.com/codex/tasks/task_e_68de6d424e0c8320b75924e4eeda47a8