### PR TITLE
Fix sticky header overlap on flag quiz 2 page

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -25,6 +25,11 @@ body {
   padding-bottom: env(safe-area-inset-bottom, 0);
 }
 
+main {
+  position: relative;
+  z-index: 0;
+}
+
 .flag-viewer-body {
   min-height: 100%;
 }
@@ -36,11 +41,11 @@ header {
   align-items: center;
   padding: 14px clamp(12px, 3vw, 28px);
   backdrop-filter: blur(6px);
-  background: linear-gradient(180deg, rgba(10, 12, 22, 0.65), rgba(10, 12, 22, 0.35));
+  background: linear-gradient(180deg, rgba(10, 12, 22, 0.82), rgba(10, 12, 22, 0.55));
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 100;
 }
 
 .brand-area {


### PR DESCRIPTION
## Summary
- ensure the main content forms its own stacking context so the sticky header stays on top while scrolling
- darken the header background for better readability when overlapping the page content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fd015a5b008320b1ef448d67dacc47